### PR TITLE
Add text beneath the bookings calendar

### DIFF
--- a/Stylesheets/layout/_fullcalendar.scss
+++ b/Stylesheets/layout/_fullcalendar.scss
@@ -77,7 +77,7 @@
 
 
 #calendar {
-  margin: 0 0 -50px;
+  margin: 0;
   table {
     border-collapse: separate;
   }

--- a/bookings.htm
+++ b/bookings.htm
@@ -37,7 +37,7 @@
               {% if data.Local.ShowAll == true %}
                 <a class="btn btn-back btn-grey btn-stacked" href="{% Url Bookings, Index, ShowAll: false %}">{% T Back to my Calendar %}</a>
               {% else %}
-                <p class="fade body-font">Click an empty time slot to make a booking.</p>
+                <h3>My Bookings</h3>
               {% endif %}
               <br /><a class="btn btn-orange mobile-show" href="#" onclick="createBooking(new Date())">{% T Make a booking %}</a>
             </div>
@@ -60,6 +60,9 @@
     		{% endif %}
 
         <div id="calendar" title="Click an empty time slot to make a booking."></div>
+        <p class="body-font fade">
+          Click an empty time slot to make a booking. For any bookings outside of these times please contact Reception.
+        </p>
       </section>
       <!-- END CONTENT -->
     </div>


### PR DESCRIPTION
Changes calendar margin to fix the new text positioning.

Replaces header text otherwise it would be duplicated
in the calendar text.

See: https://www.pivotaltracker.com/story/show/131533871

Before:
![screen shot 2016-10-07 at 11 19 06](https://cloud.githubusercontent.com/assets/1006365/19187044/3dfd2694-8c81-11e6-9bb7-809aa972b526.png)

After:
![screen shot 2016-10-07 at 11 21 24](https://cloud.githubusercontent.com/assets/1006365/19187048/4248b83a-8c81-11e6-994d-cef241c7a20a.png)
