### PR TITLE
Email updates

### DIFF
--- a/Emails/partials/new_contact.nunjucks
+++ b/Emails/partials/new_contact.nunjucks
@@ -1,0 +1,34 @@
+{% extends "layout.nunjucks" %}
+{% set subject = 'Account Active' %}
+{% set signoff = 'Stephen Wood, Membership Manager' %}
+
+{% block teaser %}
+  Your Soho Works account is active.
+{% endblock %}
+
+{% block content %}
+  <tr>
+    <td>
+      <h1>Good news {salutation}
+      <br />Your soho works account is ready to use.</h1>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <p>Log-in with the details below</p>
+      {{ field('Username', '{username}') }}
+      {{ field('Password', '{password}') }}
+      {{ field('PIN', '{accesscardid}') }}
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <p>Please go to Settings and Payments to update your payment details.</p>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      {{ button(label='Login Now', href=spaceUrl) }}
+    </td>
+  </tr>
+{% endblock %}

--- a/emails/layouts/macros.nunjucks
+++ b/emails/layouts/macros.nunjucks
@@ -17,5 +17,5 @@
 {% endmacro %}
 
 {% macro field(key, value) %}
-  <p>{% if value %}<span class="fade">{% endif %}{{key}}{% if value %}</span>: {{value}}</span>{% endif %}</p>
+  <p>{% if value %}<span class="fade">{% endif %}{{key}}{% if value %}:</span> {{value}}</span>{% endif %}</p>
 {% endmacro %}

--- a/emails/layouts/style.css
+++ b/emails/layouts/style.css
@@ -57,7 +57,7 @@ p {
   border-radius: 5px;
 }
 
-.primary-wrapper a {
+.primary-wrapper p a {
   color: white;
 }
 

--- a/emails/partials/booking_confirmation.nunjucks
+++ b/emails/partials/booking_confirmation.nunjucks
@@ -20,6 +20,7 @@
       {{ field("From", "{fromTime}") }}
       {{ field("To", "{toTime}") }}
       {{ field("Price*", "{price}") }}
+      Please see notes below if you have booking credits.
     </td>
   </tr>
   <tr>

--- a/emails/partials/new_member.nunjucks
+++ b/emails/partials/new_member.nunjucks
@@ -23,7 +23,7 @@
   </tr>
   <tr>
     <td>
-      {{ button(label='Login Now', href="http://google.com") }}
+      {{ button(label='Login Now', href=spaceUrl) }}
     </td>
   </tr>
 {% endblock %}


### PR DESCRIPTION
- Copy updates for new contact and new member emails.
- Prior to this we didn't have a copy of the new contact template.
- Use a single href for the button on new member & new contact.
- Update the colour of the text in buttons on emails.

New contact:
![screen shot 2016-10-07 at 15 38 40](https://cloud.githubusercontent.com/assets/1006365/19194147/acbe28f8-8ca4-11e6-99fe-380254a91c5a.png)

Booking confirmation:
![screen shot 2016-10-07 at 15 39 45](https://cloud.githubusercontent.com/assets/1006365/19194159/b543befc-8ca4-11e6-892d-086431e267bd.png)
