### PR TITLE
Remove image dimensions from resources page

### DIFF
--- a/resources.htm
+++ b/resources.htm
@@ -10,7 +10,7 @@
         {% for resource in data.Resources %}
         <article class="card span" style="min-height: 285px">          
           <!-- POST CONTENT -->
-          <div class="card-image" {% if resource.HasImage %} style="background-image: url({% Url PublicResources, GetImage, id: resource.Id, h: 800, w: 800 %})" {% endif %} ></div>
+          <div class="card-image" {% if resource.HasImage %} style="background-image: url({% Url PublicResources, GetImage, id: resource.Id %})" {% endif %} ></div>
           <ul class="resource_features">
             {% if resource.Allocation > 0 %}
             <li class="btn btn-grey">


### PR DESCRIPTION
Before:
![screen shot 2016-10-07 at 16 08 20](https://cloud.githubusercontent.com/assets/1006365/19195237/9c348456-8ca8-11e6-8e19-64502fb01567.png)

After:
![screen shot 2016-10-07 at 16 08 10](https://cloud.githubusercontent.com/assets/1006365/19195250/a50d71d2-8ca8-11e6-8640-e6bdd569ac33.png)
