### PR TITLE
Canned responses

### DIFF
--- a/Emails/partials/guest_canned_response.nunjucks
+++ b/Emails/partials/guest_canned_response.nunjucks
@@ -1,0 +1,15 @@
+{% extends "layout.nunjucks" %}
+{% set subject = 'Your guest has arrived' %}
+
+{% block content %}
+  <tr>
+    <td>
+      <h1>Hi {salutation},
+    </td>
+  </tr>
+  <tr>
+    <td>
+      Just a note to let you know that your guest has arrived and is waiting in reception for you.
+    </td>
+  </tr>
+{% endblock %}

--- a/Emails/partials/meeting_room_extension_canned_response.nunjucks
+++ b/Emails/partials/meeting_room_extension_canned_response.nunjucks
@@ -1,0 +1,15 @@
+{% extends "layout.nunjucks" %}
+{% set subject = 'Your meeting has ended' %}
+
+{% block content %}
+  <tr>
+    <td>
+      <h1>Hi {salutation},
+    </td>
+  </tr>
+  <tr>
+    <td>
+      Just a note to let you know that your meeting room booking time has ended. Please reply to this email if you need to extend your booking.
+    </td>
+  </tr>
+{% endblock %}

--- a/Emails/partials/parcel_canned_response.nunjucks
+++ b/Emails/partials/parcel_canned_response.nunjucks
@@ -1,0 +1,15 @@
+{% extends "layout.nunjucks" %}
+{% set subject = 'You have a parcel' %}
+
+{% block content %}
+  <tr>
+    <td>
+      <h1>Hi {salutation},
+    </td>
+  </tr>
+  <tr>
+    <td>
+      Just a note to let you know that you have had a parcel delivered. Please come round to reception to collect it.
+    </td>
+  </tr>
+{% endblock %}


### PR DESCRIPTION
Adds styled canned responses for the following:
#### Guest arrival:

![screen shot 2016-10-10 at 11 31 36](https://cloud.githubusercontent.com/assets/1006365/19233398/31dfbbb6-8edd-11e6-96b5-d089f47a6779.png)
#### Parcel delivered:

![screen shot 2016-10-10 at 11 29 58](https://cloud.githubusercontent.com/assets/1006365/19233408/392a73b6-8edd-11e6-9f19-34c29a046eed.png)
#### Meeting room extension:

![screen shot 2016-10-10 at 11 30 41](https://cloud.githubusercontent.com/assets/1006365/19233413/3de390b8-8edd-11e6-9900-05db5c1c5137.png)

See: https://www.pivotaltracker.com/story/show/128075153
