### PR TITLE
Fix long event description getting out of description box

### DIFF
--- a/Stylesheets/layout/_cards.scss
+++ b/Stylesheets/layout/_cards.scss
@@ -20,7 +20,7 @@ article.card {
 
   @media (min-width: $medium) {
     height: 460px;
-    
+
     .card-hover {
       position: absolute;
       bottom: -5px;
@@ -72,6 +72,10 @@ article.card {
       padding-left: 40%;
       width: 97.5%;
       height: 260px;
+
+      &.full-height {
+        height: auto;
+      }
       
       .card-content {
         padding: 20px 20px 20px 40px;

--- a/event-tickets.htm
+++ b/event-tickets.htm
@@ -4,7 +4,7 @@
 <div id="wrapper">
   <div id="main" class="container basic">
     <div class="row card-wrapper--list">
-      <article class="card span card--no-hover">
+      <article class="card span card--no-hover full-height">
         <a href="{% Url Events, Tickets, Id: data.Local.Event.Id, title: data.Local.Event.Name | Clean %}">
           <div class="card-image" style="background-image: url({% Url Events, GetLargeImage, id: data.Local.Event.Id, w: 870 %})"></div>
         </a>


### PR DESCRIPTION
Fix for https://sohohouse.sifterapp.com/issues/751