### PR TITLE
Make card heights adapt more generally to description

### DIFF
--- a/Custom/event_card.htm
+++ b/Custom/event_card.htm
@@ -7,7 +7,7 @@
   {% endfor %}
 {% endif %}
 
-<article class="card span {% if soldOut or (hasTickets == false) %}card--no-hover{% endif %} {% if soldOut %}card--error{% endif %}">
+<article class="card span {% if soldOut or (hasTickets == false) %}card--no-hover{% endif %} {% if soldOut %}card--error{% endif %} height-auto">
   <a href="{% Url Events, Tickets, Id: ev.Id, title: ev.Name | Clean %}">
     <div class="card-image" style="background-image: url({% Url Events, GetLargeImage, id: ev.Id, w: 870 %})"></div>
   </a>

--- a/Stylesheets/layout/_cards.scss
+++ b/Stylesheets/layout/_cards.scss
@@ -71,9 +71,9 @@ article.card {
     .card-wrapper--list & {
       padding-left: 40%;
       width: 97.5%;
-      height: 260px;
+      min-height: 260px;
 
-      &.full-height {
+      &.height-auto {
         height: auto;
       }
       

--- a/event-tickets.htm
+++ b/event-tickets.htm
@@ -4,7 +4,7 @@
 <div id="wrapper">
   <div id="main" class="container basic">
     <div class="row card-wrapper--list">
-      <article class="card span card--no-hover full-height">
+      <article class="card span card--no-hover height-auto">
         <a href="{% Url Events, Tickets, Id: data.Local.Event.Id, title: data.Local.Event.Name | Clean %}">
           <div class="card-image" style="background-image: url({% Url Events, GetLargeImage, id: data.Local.Event.Id, w: 870 %})"></div>
         </a>


### PR DESCRIPTION
In the events list, events had height fixed to 260px, even if the description is long. We changed the fixed height into min-height to adapt to the description height.