### PR TITLE
Escape apostrophes in event notes

### DIFF
--- a/Custom/event_json.js
+++ b/Custom/event_json.js
@@ -21,7 +21,7 @@ var eventSources = [
             editable: false,
             ignoreTimezone: true,
             color: getColurFromName('{{ event.Resource.Name | Replace: "'", "\'" }}'),
-            notes: '{{ event.Notes | StripNewlines }}'
+            notes: '{{ event.Notes | StripNewlines | Replace: "'", "\'" }}'
           },
         {% endif %}
       {% endfor %}
@@ -46,7 +46,7 @@ var eventSources = [
             editable: false,
             ignoreTimezone: true,
             color: getColurFromName('{{ event.Resource.Name | Replace: "'", "\'" }}'),
-            notes: '{{ event.Notes | StripNewlines }}'
+            notes: '{{ event.Notes | StripNewlines | Replace: "'", "\'" }}'
           },
         {% endif %}
       {% endfor %}


### PR DESCRIPTION
Notes that included apostrophes were breaking the JSON. We need to escape the apostrophes when generating the templates.